### PR TITLE
Add support for data poisoning attacks

### DIFF
--- a/byzfl/fed_framework/__init__.py
+++ b/byzfl/fed_framework/__init__.py
@@ -16,3 +16,4 @@ from .server import Server
 # Import clients last, as they may depend on server or ModelBaseInterface
 from .client import Client
 from .byzantine_client import ByzantineClient
+from .poisoning_client import PoisoningClient

--- a/byzfl/fed_framework/client.py
+++ b/byzfl/fed_framework/client.py
@@ -12,7 +12,7 @@ class Client(ModelBaseInterface):
             raise TypeError(f"'params' must be of type dict, but got {type(params).__name__}")
         if not isinstance(params["loss_name"], str):
             raise TypeError(f"'loss_name' must be of type str, but got {type(params['loss_name']).__name__}")
-        if not isinstance(params["LabelFlipping"], bool):
+        if "LabelFlipping" in params and not isinstance(params["LabelFlipping"], bool):
             raise TypeError(f"'LabelFlipping' must be of type bool, but got {type(params['LabelFlipping']).__name__}")
         if not isinstance(params["nb_labels"], int) or not params["nb_labels"] > 1:
             raise ValueError(f"'nb_labels' must be an integer greater than 1")
@@ -37,7 +37,7 @@ class Client(ModelBaseInterface):
 
         self.criterion = getattr(torch.nn, params["loss_name"])()
         self.gradient_LF = 0
-        self.labelflipping = params["LabelFlipping"]
+        self.labelflipping = params.get("LabelFlipping", False)
         self.nb_labels = params["nb_labels"]
         self.momentum = params["momentum"]
         self.momentum_gradient = torch.zeros_like(

--- a/byzfl/fed_framework/poisoning_client.py
+++ b/byzfl/fed_framework/poisoning_client.py
@@ -1,0 +1,208 @@
+from copy import deepcopy
+import inspect
+
+import numpy as np
+
+from byzfl.poisoning import attacks
+from byzfl.fed_framework.client import Client
+
+
+class PoisoningClient(Client):
+    """
+    Initialization Parameters
+    -------------------------
+    client_params : dict
+        A dictionary with the client configuration. See `Client` for more information.
+    attack_params : dict
+        A dictionary containing the configuration for the data poisoning attack. Must include:
+        - `"p"`: float
+            The proportion of samples to poison.
+        - `"name"`: str
+            The name of the attack to be executed (e.g., `"StaticLabelFlipping"`).
+        - `"parameters"`: dict
+            A dictionary of parameters for the specified attack, where keys are parameter names and values are their corresponding values.
+        The attack must be callable with the following arguments:
+        - model : torch.nn.Module
+            The local model.
+        - inputs : numpy.ndarray or torch.Tensor
+            A collection of input features.
+        - targets : numpy.ndarray or torch.Tensor
+            A collection of targets.
+
+    Methods
+    -------
+    apply_attack(inputs, targets)
+        Applies the specified poisoning attack to the samples owned by the poisoning client and returns a tuple of corrupted inputs and targets.
+
+    Calling the Instance
+    --------------------
+    Input Parameters
+    ----------------
+    inputs : numpy.ndarray or torch.Tensor
+        A collection of input features.
+    targets : numpy.ndarray or torch.Tensor
+        A collection of targets.
+
+    Returns
+    -------
+    tuple
+        A tuple containing the inputs and targets poisoned by the attack with proportion `p`,
+        each with the same data type as the inputs and targets provided to the instance.
+    
+    Notes
+    -----
+    - Contrary to `ByzantineClient`, a `PoisoningClient` is drop-in compatible with an honest
+    `Client`.
+    - The training losses are computed on the corrupted data.
+
+    Examples
+    --------
+    Initialize the `PoisoningClient` with a specific attack:
+
+    >>> import torch
+    >>> from torch.utils.data import DataLoader
+    >>> from torchvision import datasets, transforms
+    >>> from byzfl import PoisoningClient
+    >>>
+    >>> transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.5,), (0.5,))])
+    >>> train_dataset = datasets.MNIST(root="./data", train=True, download=True, transform=transform)
+    >>> train_loader = DataLoader(train_dataset, batch_size=64, shuffle=True)
+    >>>
+    >>> params = {
+    >>>     "model_name": "fc_mnist",
+    >>>     "device": "cpu",
+    >>>     "weight_decay": 1e-5,
+    >>>     "optimizer_name": "Adam",
+    >>>     "optimizer_params": {"betas": (0.9, 0.999)},
+    >>>     "learning_rate": 0.01,
+    >>>     "loss_name": "CrossEntropyLoss",
+    >>>     "weight_decay": 0.0005,
+    >>>     "milestones": [10, 20],
+    >>>     "learning_rate_decay": 0.5,
+    >>>     "momentum": 0.9,
+    >>>     "training_dataloader": train_loader,
+    >>>     "nb_labels": 10,
+    >>> }
+    >>>
+    >>> attack = {
+    >>>     "name": "StaticLabelFlipping",
+    >>>     "parameters": {"permutation": {i: 9 - i for i in range(10)}},
+    >>> }
+    >>> poisoning_worker = PoisoningClient(params, attack)
+    """
+
+    def __init__(self, client_params, attack_params):
+        """
+        Initializes the `PoisoningClient` with the specified client parameters and
+        attack configuration.
+
+        Parameters
+        ----------
+        client_params : dict
+            A dictionary with the client configuration. See `Client` for more information.
+        attack_params : dict
+            A dictionary with the attack configuration. Must include:
+            - `"p"`: float
+                The proportion of samples to poison.
+            - `"name"`: str
+                Name of the poisoning attack to execute.
+            - `"parameters"`: dict
+                Parameters for the specified attack.
+        """
+
+        super().__init__(client_params)
+        self._init_poisoning_attack(attack_params)
+    
+    def _init_poisoning_attack(self, params):
+        """
+        Description
+        -----------
+        Initialize the `PoisoningClient` with the specified attack configuration.
+        """
+        # Check for correct types and values in params
+        if not isinstance(params, dict):
+            raise TypeError("params must be a dictionary")
+        if "p" not in params or not isinstance(params["p"], float) or not 0.0 <= params["p"] <= 1:
+            raise ValueError("p must be a float between 0.0 and 1.0")
+        if "name" not in params or not isinstance(params["name"], str):
+            raise TypeError("name must be a string")
+        if "parameters" not in params or not isinstance(params["parameters"], dict):
+            raise TypeError("parameters must be a dictionary")
+
+        # Initialize the PoisoningClient instance
+        self.no_attack = False
+        self.p = params["p"]
+
+        if params["name"] == "NoAttack":
+            self.no_attack = True
+            return
+
+        self.attack = getattr(attacks, params["name"])
+        signature_attack = inspect.signature(self.attack.__init__)
+
+        filtered_parameters = {}
+        for parameter in signature_attack.parameters.values():
+            param_name = parameter.name
+            if param_name in params["parameters"]:
+                filtered_parameters[param_name] = params["parameters"][param_name]
+
+        self.attack = self.attack(**filtered_parameters)
+    
+    def _sample_train_batch(self):
+        """
+        Description
+        -----------
+        Retrieves the next batch of data from the training dataloader, after applying the
+        poisoning attack. If the end of the dataset is reached, the dataloader is
+        reinitialized to start from the beginning.
+
+        Returns
+        -------
+        tuple
+            A tuple containing the input data and corresponding target labels
+            for the current batch, after applying the poisoning attack. The tensors are
+            sent to `self.device`.
+        """
+        inputs, targets = super()._sample_train_batch()
+        inputs, targets = inputs.to(self.device), targets.to(self.device)
+        return self.apply_attack(inputs, targets)
+    
+    def apply_attack(self, inputs, targets):
+        """
+        Applies the specified poisoning attack to the samples owned by the poisoning client.
+
+        Parameters
+        ----------
+        inputs : numpy.ndarray or torch.Tensor
+            A collection of input features.
+        targets : numpy.ndarray or torch.Tensor
+            A collection of targets.
+
+        Returns
+        -------
+        tuple
+            A tuple containing the inputs and targets poisoned by the attack with proportion `p`,
+            each with the same data type as the inputs and targets provided to the instance.
+            If `no_attack` is `True`, the arguments are returned.
+        """
+        if len(inputs) != len(targets):
+            raise ValueError("Inputs and targets lengths mismatch")
+
+        inputs, targets = deepcopy((inputs, targets))
+        if self.no_attack:
+            return inputs, targets
+
+        n = len(inputs)
+        m = int(self.p * n)
+        poisoned_indices = np.random.choice(n, m, replace=False)
+
+        # Generate the poisoned samples by applying the attack
+        poisoned_inputs, poisoned_targets = self.attack(
+            self.model,
+            inputs[poisoned_indices],
+            targets[poisoned_indices],
+        )
+        inputs[poisoned_indices] = poisoned_inputs
+        targets[poisoned_indices] = poisoned_targets
+
+        return inputs, targets

--- a/byzfl/poisoning/__init__.py
+++ b/byzfl/poisoning/__init__.py
@@ -1,0 +1,1 @@
+from .attacks import *

--- a/byzfl/poisoning/attacks.py
+++ b/byzfl/poisoning/attacks.py
@@ -1,0 +1,45 @@
+
+from copy import deepcopy
+
+
+class StaticLabelFlipping(object): 
+    """
+    Description
+    -----------
+
+    Flip target labels with a fixed permutation.
+
+    Initialization parameters
+    --------------------------
+
+    permutation: dict
+        A dictionary that maps a label to its flipped version.
+
+    Calling the instance
+    --------------------
+
+    Input parameters
+    ----------------
+
+    model : torch.nn.Module
+        The local model.
+    inputs : numpy.ndarray or torch.Tensor
+        A collection of input features.
+    targets : numpy.ndarray or torch.Tensor
+        A collection of targets.
+
+    Returns
+    -------
+    tuple
+        The inputs and targets with flipped labels.
+    """
+    def __init__(self, permutation):
+        if not isinstance(permutation, dict):
+            raise TypeError("permutation must be a dict.")
+        self.permutation = permutation
+    
+    def __call__(self, model, inputs, targets):
+        for i, target in enumerate(targets.numpy()):
+            targets[i] = self.permutation[target]
+        
+        return inputs, targets


### PR DESCRIPTION
# Problem

Unlike gradient attacks, label flipping is a data poisoning attack, which is why it gets special treatment in the ByzFL implementation. However, this upstream implementation of label flipping is **not modular**. In order to perform label flipping, the attacker needs to have data. ByzFL currently works around the `ByzantineClient` which is designed to perform gradient attacks, not poisoning attacks.

## How the upstream ByzFL handles label flipping

With `LabelFlipping`, the attacker is **omniscient**  and has access to the features and labels of the clients. The attacker first computes the gradients with label flipping applied to honest clients' data, and then sends the mean gradient to the server.
But because a `ByzantineClient` has no knowledge of the actual data, **computing the gradients with label flipping has to be performed by the honest `Client` instances**. This is not a long-term solution for other types of data poisoning.

# Solution

Instead of working around a `ByzantineClient`, we create a `PoisoningClient(Client)` class which provides a generic method to perform data poisoning. This client has the **same status as an honest `Client`**: it is provided a share of the training dataset and poisons a fraction `p` of it.

A poisoning attack can be any callable with the signature `(model, inputs, targets) -> (inputs, targets)`.

This client can now perform any type of label flipping, including _dynamic_ label flipping since it has **access to the model weights**. Furthermore, adding a `PoisoningClient` paves the way for more types of non-omniscient data poisoning attacks, such as gradient inversion.